### PR TITLE
:bug: fix sw generation errors

### DIFF
--- a/web/workbox-config.js
+++ b/web/workbox-config.js
@@ -1,10 +1,10 @@
 // eslint-disable-next-line no-undef
 module.exports = {
-  globDirectory: 'dist',
+  globDirectory: 'build',
   globPatterns: [
     '**/*.{html,js,css,png,svg,jpg,gif,json,woff,woff2,eot,ico,webmanifest,map}',
   ],
-  swDest: 'dist/service-worker.js',
+  swDest: 'build/service-worker.js',
   clientsClaim: true,
   skipWaiting: true,
 };


### PR DESCRIPTION
Fixed bug where the service worker generation with workbox would fail.

The bug was caused by an incorrect `globDirectory` in the `workbox.config.js`.